### PR TITLE
feat: add support for xaml and svg code blocks in markdown tokenizer

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -40,7 +40,7 @@ Handling this metadata correctly is essential to render the markdown accurately.
 
 #### Code block metadata
 - `CSharpCodeBlockMetadata`
-- `XmlCodeBlockMetadata`
+- `XmlCodeBlockMetadata` (also used for XAML and SVG code blocks)
 - `TypeScriptCodeBlockMetadata`
 - `JsonCodeBlockMetadata`
 - `SqlCodeBlockMetadata`
@@ -278,6 +278,10 @@ The Markdown Tokenizer produces tokens of type `MarkdownTokenType` with the foll
 - `HtmlTag` - Represents an HTML tag (value contains complete tag including `< >` markers)
 
 More info: [MarkdownTokenType.cs](https://github.com/crwsolutions/ntokenizers/blob/main/src/NTokenizers/Markdown/MarkdownTokenType.cs)
+
+## Supported Code Block Languages
+
+The Markdown Tokenizer supports code blocks for many languages. Code blocks using `xml`, `xaml`, or `svg` language identifiers all use the same XML tokenizer, since XAML and SVG are XML-based formats.
 
 ## See Also
 

--- a/src/NTokenizers/Markdown/MarkdownTokenizer.cs
+++ b/src/NTokenizers/Markdown/MarkdownTokenizer.cs
@@ -313,27 +313,27 @@ public sealed class MarkdownTokenizer : BaseMarkdownTokenizer
     }
 
     private async Task<bool> ParseCodeInlines(string language) => language.Trim().ToLowerInvariant() switch
-         {
-             "csharp" or "cs" or "c#" => await ParseCodeInlines(new CSharpCodeBlockMetadata(language)),
-             "json" => await ParseCodeInlines(new JsonCodeBlockMetadata(language)),
-             "xml" => await ParseCodeInlines(new XmlCodeBlockMetadata(language)),
-             "html" => await ParseCodeInlines(new HtmlCodeBlockMetadata(language)),
-             "yaml" => await ParseCodeInlines(new YamlCodeBlockMetadata(language)),
-             "sql" => await ParseCodeInlines(new SqlCodeBlockMetadata(language)),
-             "typescript" or "ts" or "javascript" or "js" => await ParseCodeInlines(new TypeScriptCodeBlockMetadata(language)),
-             "css" => await ParseCodeInlines(new CssCodeBlockMetadata(language)),
-             "toml" => await ParseCodeInlines(new TomlCodeBlockMetadata(language)),
-             "java" => await ParseCodeInlines(new JavaCodeBlockMetadata(language)),
-             "c" => await ParseCodeInlines(new CCodeBlockMetadata(language)),
-"cpp" or "c++" => await ParseCodeInlines(new CppCodeBlockMetadata(language)),
-"rust" or "rs" => await ParseCodeInlines(new RustCodeBlockMetadata(language)),
-"kotlin" or "kt" => await ParseCodeInlines(new KotlinCodeBlockMetadata(language)),
-"go" or "golang" => await ParseCodeInlines(new GoCodeBlockMetadata(language)),
-"swift" => await ParseCodeInlines(new SwiftCodeBlockMetadata(language)),
-             _ => await ParseCodeInlines(new GenericCodeBlockMetadata(language))
-         };
+    {
+        "csharp" or "cs" or "c#" => await ParseCodeInlines(new CSharpCodeBlockMetadata(language)),
+        "json" => await ParseCodeInlines(new JsonCodeBlockMetadata(language)),
+        "xml" or "xaml" or "svg" => await ParseCodeInlines(new XmlCodeBlockMetadata(language)),
+        "html" => await ParseCodeInlines(new HtmlCodeBlockMetadata(language)),
+        "yaml" => await ParseCodeInlines(new YamlCodeBlockMetadata(language)),
+        "sql" => await ParseCodeInlines(new SqlCodeBlockMetadata(language)),
+        "typescript" or "ts" or "javascript" or "js" => await ParseCodeInlines(new TypeScriptCodeBlockMetadata(language)),
+        "css" => await ParseCodeInlines(new CssCodeBlockMetadata(language)),
+        "toml" => await ParseCodeInlines(new TomlCodeBlockMetadata(language)),
+        "java" => await ParseCodeInlines(new JavaCodeBlockMetadata(language)),
+        "c" => await ParseCodeInlines(new CCodeBlockMetadata(language)),
+        "cpp" or "c++" => await ParseCodeInlines(new CppCodeBlockMetadata(language)),
+        "rust" or "rs" => await ParseCodeInlines(new RustCodeBlockMetadata(language)),
+        "kotlin" or "kt" => await ParseCodeInlines(new KotlinCodeBlockMetadata(language)),
+        "go" or "golang" => await ParseCodeInlines(new GoCodeBlockMetadata(language)),
+        "swift" => await ParseCodeInlines(new SwiftCodeBlockMetadata(language)),
+        _ => await ParseCodeInlines(new GenericCodeBlockMetadata(language))
+    };
 
-       private bool TryParseCustomContainer()
+    private bool TryParseCustomContainer()
     {
         if (PeekAhead(0) != ':' || PeekAhead(1) != ':' || PeekAhead(2) != ':')
             return false;

--- a/tests/NTokenizers.ShowCase.Markdown/Program.cs
+++ b/tests/NTokenizers.ShowCase.Markdown/Program.cs
@@ -48,6 +48,21 @@ class Program
         </user>
         ```
 
+        ## XAML example
+        ```xaml
+        <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                Title="My App" Height="450" Width="800">
+            <Button Content="Click me" />
+        </Window>
+        ```
+        
+        ## SVG example
+        ```svg
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="40" fill="red" />
+        </svg>
+        ```
+
         ## HTML example
         ```html
         <html>

--- a/tests/NTokenizers.Tests/MarkdownTokenizerTests.cs
+++ b/tests/NTokenizers.Tests/MarkdownTokenizerTests.cs
@@ -88,7 +88,7 @@ public class MarkdownTokenizerTests
             }
             else if (token.Metadata is XmlCodeBlockMetadata xmlMeta)
             {
-                // For XML code blocks, we receive XmlToken objects
+                // For XML, XAML, and SVG code blocks, we receive XmlToken objects
                 xmlMeta.RegisterInlineTokenHandler(token => { });
             }
             else if (token.Metadata is HtmlCodeBlockMetadata htmlMeta)
@@ -1096,5 +1096,46 @@ Visit [Google](https://google.com) for more.";
             var codeBlockTokens = tokens.Where(t => t.TokenType == MarkdownTokenType.CodeBlock).ToList();
             Assert.NotEmpty(codeBlockTokens);
             Assert.IsType<CCodeBlockMetadata>(codeBlockTokens[0].Metadata);
+        }
+
+        [Fact]
+        public void TestXamlCodeBlock()
+        {
+            var markdown = """
+    ## XAML Example
+    ```xaml
+    <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            Title="My App" Height="450" Width="800">
+        <Button Content="Click me" />
+    </Window>
+    ```
+    """;
+
+            var (tokens, text) = Tokenize(markdown);
+            Assert.Contains(tokens, t => t.TokenType == MarkdownTokenType.Heading);
+            Assert.Contains(tokens, t => t.TokenType == MarkdownTokenType.CodeBlock);
+            var codeBlockTokens = tokens.Where(t => t.TokenType == MarkdownTokenType.CodeBlock).ToList();
+            Assert.NotEmpty(codeBlockTokens);
+            Assert.IsType<XmlCodeBlockMetadata>(codeBlockTokens[0].Metadata);
+        }
+
+        [Fact]
+        public void TestSvgCodeBlock()
+        {
+            var markdown = """
+    ## SVG Example
+    ```svg
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="40" fill="red" />
+    </svg>
+    ```
+    """;
+
+            var (tokens, text) = Tokenize(markdown);
+            Assert.Contains(tokens, t => t.TokenType == MarkdownTokenType.Heading);
+            Assert.Contains(tokens, t => t.TokenType == MarkdownTokenType.CodeBlock);
+            var codeBlockTokens = tokens.Where(t => t.TokenType == MarkdownTokenType.CodeBlock).ToList();
+            Assert.NotEmpty(codeBlockTokens);
+            Assert.IsType<XmlCodeBlockMetadata>(codeBlockTokens[0].Metadata);
         }
     }


### PR DESCRIPTION
Update the markdown tokenizer to recognize 'xaml' and 'svg' as XML-based code block languages, routing them to the XmlCodeBlockMetadata parser.

Also update documentation to reflect this behavior and clarify the supported code block languages.